### PR TITLE
Modified sftp.py

### DIFF
--- a/.ENV.TXT
+++ b/.ENV.TXT
@@ -1,4 +1,0 @@
-HOSTNAME=Avatar_CSI300_G4
-USERNAME=!------!
-PRIVATE_KEY_PATH=/GitHub/Avatar_CSCI3000_G4/.ENV.TXT/file-transfer/sftp.py
-PRIVATE_KEY_PASS=!----!----!

--- a/file-transfer/sftp.py
+++ b/file-transfer/sftp.py
@@ -1,13 +1,14 @@
 import pysftp
 import sys
+from decouple import config
 
 #this file is expected to be modifed once for every single chromebook in our BCI lab
 class fileTransfer:
     def __init__(self):
-        self.host = ''  # change
-        self.username = ''  # change
-        self.private_key = ''  # change
-        self.private_key_pass = ''  # change
+        self.host = config('HOST', default='')
+        self.username = config('USERNAME', default='')
+        self.private_key = config('PRIVATE_KEY_PATH', default='')
+        self.private_key_pass = config('PRIVATE_KEY_PASS', default='')
         self.port = 22
         self.serverconn = self.connect()
 


### PR DESCRIPTION
Updated sftp.py to use the Python "decouple" library to read user data from a .env File. This will allow user information to be stored locally on their machine, and not within Github itself. 

Uses the "config" command that by default searches for a .env file for a matching variable declaration and assigns its value. 