### PR TITLE
Modified .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+*.env

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ README.md
 
 
 # Environments
-**/.env
-.env
 .venv
 env/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ README.md
 
 
 # Environments
+**/.env
 .env
 .venv
 env/

--- a/file-transfer/UserData.env
+++ b/file-transfer/UserData.env
@@ -1,0 +1,4 @@
+HOSTNAME=your_hostname_or_ip
+USERNAME=your_username
+PRIVATE_KEY_PATH=path/to/your/private/key
+PRIVATE_KEY_PASS=your_private_key_pass

--- a/file-transfer/UserData.env
+++ b/file-transfer/UserData.env
@@ -1,4 +1,0 @@
-HOSTNAME=your_hostname_or_ip
-USERNAME=your_username
-PRIVATE_KEY_PATH=path/to/your/private/key
-PRIVATE_KEY_PASS=your_private_key_pass


### PR DESCRIPTION
Modified .gitignore to ignore all .env files. The previous command did not prevent .env files from being tracked and committed. This update prevents .env files from being tracked in root and all subdirectories. 